### PR TITLE
Delete CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of Conduct
-
-The code of conduct for this project can be found at https://swift.org/code-of-conduct.
-
-<!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
we are using the .github Org wide code of conduct. having this file present means that this repo is opting out of that, which it is not.