### PR TITLE
add optional Aside intiailizer that bails if it can't find a tag

### DIFF
--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -190,10 +190,18 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
     /// Returns a new `RawMarkup` element replacing the slot at the given index with a new element.
     /// - note: The new element's `range` will be `nil`, as this API creates a new element outside of the parser.
     /// - precondition: The given index must be within the bounds of the children.
-    func substitutingChild(_ newChild: RawMarkup, at index: Int) -> RawMarkup {
+    func substitutingChild(_ newChild: RawMarkup, at index: Int, preserveRange: Bool = false) -> RawMarkup {
         var newChildren = copyChildren()
         newChildren[index] = newChild
-        return RawMarkup.create(data: header.data, parsedRange: newChild.header.parsedRange, children: newChildren)
+
+        let parsedRange: SourceRange?
+        if preserveRange {
+            parsedRange = header.parsedRange ?? newChild.header.parsedRange
+        } else {
+            parsedRange = newChild.header.parsedRange
+        }
+
+        return RawMarkup.create(data: header.data, parsedRange: parsedRange, children: newChildren)
     }
 
     func withChildren<Children: Collection>(_ newChildren: Children) -> RawMarkup where Children.Element == RawMarkup {

--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -221,6 +221,10 @@ extension BlockQuote {
             $0 == " " || $0 == "\t"
         }
 
+        guard tagRequirement != .requireSingleWordTag || !kindTag.contains(" ") else {
+            return nil
+        }
+
         let shiftCount = kindTag.count + 1 + initialText.string[firstColonIndex...].dropFirst().prefix(while: {
             $0 == " " || $0 == "\t"
         }).count
@@ -242,10 +246,6 @@ extension BlockQuote {
             "Parsing didn't lose the original source information"
         )
 
-        if tagRequirement == .requireSingleWordTag, kindTag.contains(" ") {
-            return nil
-        } else {
-            return (String(kindTag), newBlockQuote)
-        }
+        return (String(kindTag), newBlockQuote)
     }
 }

--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -225,7 +225,7 @@ extension BlockQuote {
             return nil
         }
 
-        let shiftCount = kindTag.count + 1 + initialText.string[firstColonIndex...].dropFirst().prefix(while: {
+        let shiftCount = kindTag.utf8.count + 1 + initialText.string[firstColonIndex...].dropFirst().prefix(while: {
             $0 == " " || $0 == "\t"
         }).count
         let textRange: SourceRange? = initialText.range.map({ originalRange in

--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -66,8 +66,7 @@ public struct HTMLFormatter: MarkupWalker {
     // MARK: Block elements
 
     public mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> () {
-        if blockQuote.isAside() {
-            let aside = Aside(blockQuote)
+        if self.options.contains(.parseAsides), let aside = Aside(blockQuote, tagRequirement: .requireSingleWordTag) {
             result += "<aside data-kind=\"\(aside.kind.rawValue)\">\n"
             for child in aside.content {
                 visit(child)

--- a/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
+++ b/Tests/MarkdownTests/Interpretive Nodes/AsideTests.swift
@@ -93,10 +93,10 @@ class AsideTests: XCTestCase {
         do {
             let source = "> Important: This is an aside."
             let expectedRootDump = """
-            Document
-            └─ BlockQuote
-               └─ Paragraph
-                  └─ Text "This is an aside."
+            Document @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+            └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+               └─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:31
+                  └─ Text @/path/to/some-file.md:1:14-/path/to/some-file.md:1:31 "This is an aside."
             """
             try assertAside(
                 source: source,
@@ -119,10 +119,10 @@ class AsideTests: XCTestCase {
         do {
             let source = "> See Also: A different topic."
             let expectedRootDump = """
-            Document
-            └─ BlockQuote
-               └─ Paragraph
-                  └─ Text "A different topic."
+            Document @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+            └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+               └─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:31
+                  └─ Text @/path/to/some-file.md:1:13-/path/to/some-file.md:1:31 "A different topic."
             """
             try assertAside(
                 source: source,
@@ -134,10 +134,10 @@ class AsideTests: XCTestCase {
         do {
             let source = "> Important: This is an aside."
             let expectedRootDump = """
-            Document
-            └─ BlockQuote
-               └─ Paragraph
-                  └─ Text "This is an aside."
+            Document @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+            └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+               └─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:31
+                  └─ Text @/path/to/some-file.md:1:14-/path/to/some-file.md:1:31 "This is an aside."
             """
             try assertAside(
                 source: source,
@@ -153,10 +153,10 @@ class AsideTests: XCTestCase {
             > This is a regular block quote.
             """
             let expectedRootDump = """
-            Document
-            └─ BlockQuote
-               └─ Paragraph
-                  └─ Text "This is a regular block quote."
+            Document @/path/to/some-file.md:1:1-/path/to/some-file.md:1:33
+            └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:33
+               └─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:33
+                  └─ Text @/path/to/some-file.md:1:3-/path/to/some-file.md:1:33 "This is a regular block quote."
             """
             try assertAside(
                 source: source,
@@ -168,10 +168,10 @@ class AsideTests: XCTestCase {
         do {
             let source = "> See Also: A different topic."
             let expectedRootDump = """
-            Document
-            └─ BlockQuote
-               └─ Paragraph
-                  └─ Text "A different topic."
+            Document @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+            └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+               └─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:31
+                  └─ Text @/path/to/some-file.md:1:13-/path/to/some-file.md:1:31 "A different topic."
             """
             try assertAside(
                 source: source,
@@ -183,10 +183,10 @@ class AsideTests: XCTestCase {
         do {
             let source = "> Important: This is an aside."
             let expectedRootDump = """
-            Document
-            └─ BlockQuote
-               └─ Paragraph
-                  └─ Text "This is an aside."
+            Document @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+            └─ BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:31
+               └─ Paragraph @/path/to/some-file.md:1:3-/path/to/some-file.md:1:31
+                  └─ Text @/path/to/some-file.md:1:14-/path/to/some-file.md:1:31 "This is an aside."
             """
             try assertAside(
                 source: source,
@@ -197,10 +197,23 @@ class AsideTests: XCTestCase {
     }
 
     func assertAside(source: String, conversionStrategy: Aside.TagRequirement, expectedKind: Aside.Kind, expectedRootDump: String, file: StaticString = #file, line: UInt = #line) throws {
-        let document = Document(parsing: source)
+        let fakeFileLocation = URL(fileURLWithPath: "/path/to/some-file.md")
+        let document = Document(parsing: source, source: fakeFileLocation)
         let blockQuote = document.child(at: 0) as! BlockQuote
         let aside = try XCTUnwrap(Aside(blockQuote, tagRequirement: conversionStrategy))
+
+        XCTAssertEqual(
+            blockQuote.range?.lowerBound.source,
+            aside.content.first?.range?.lowerBound.source,
+            "The parsed aside should not lose source file information",
+            file: file, line: line
+        )
+
         XCTAssertEqual(expectedKind, aside.kind, file: file, line: line)
-        XCTAssertEqual(expectedRootDump, aside.content[0].root.debugDescription(), file: file, line: line)
+        XCTAssertEqual(
+            expectedRootDump,
+            aside.content[0].root.debugDescription(options: .printSourceLocations),
+            file: file, line: line
+        )
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: Resolves #139

## Summary

This PR adds a new initializer to Aside that only returns a new instance if it successfully finds an aside tag at the beginning of the block-quote. To make the API fully flexible, this API introduces three separate modes to this initializer:

1. `tagNotRequired`, which defers to the currently-available initializer that creates a `.note` aside if it can't find a tag,
2. `requireSingleWordTag`, which requires that the block starts with a single-word tag (and is used by the new HTML formatter), and
3. `requireAnyLengthTag`, which requires that the block starts with a tag (defined as any text prefixed by a colon), even tags with multiple words like `See Also:`.

## Dependencies

None

## Testing

As this is an API-only change, the testing strategy is limited to automated testing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
