### PR TITLE
mark CAtomic import as internal or implementation-only

### DIFF
--- a/Sources/Markdown/Utility/AtomicCounter.swift
+++ b/Sources/Markdown/Utility/AtomicCounter.swift
@@ -8,7 +8,7 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if compiler(>=5.10)
+#if compiler(>=6.0)
 internal import CAtomic
 #else
 @_implementationOnly import CAtomic

--- a/Sources/Markdown/Utility/AtomicCounter.swift
+++ b/Sources/Markdown/Utility/AtomicCounter.swift
@@ -8,7 +8,11 @@
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import CAtomic
+#if compiler(>=5.10)
+internal import CAtomic
+#else
+@_implementationOnly import CAtomic
+#endif
 
 /// A wrapper for a 64-bit unsigned atomic singleton counter.
 struct AtomicCounter {


### PR DESCRIPTION
Bug/issue #, if applicable: fixes rdar://134894555, fixes #195

## Summary

The CAtomic target defined in this package is causing issues when verifying module interfaces of projects that depend on Swift-Markdown. This PR marks the import of CAtomic in Swift-Markdown as `internal` or `@_implementationOnly`, depending on the compiler in use, to sidestep the issue.

## Dependencies

None

## Testing

Ensure that no behavior has changed.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
