### PR TITLE
don't automatically transfer the child elements' ranges to the parent

### DIFF
--- a/Sources/Markdown/Base/Document.swift
+++ b/Sources/Markdown/Base/Document.swift
@@ -65,11 +65,11 @@ public extension Document {
     }
 
     /// Create a document from a sequence of block markup elements.
-    init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup {
+    init(_ children: some Sequence<BlockMarkup>) {
         self.init(children, inheritSourceRange: false)
     }
 
-    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+    init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
         let rawChildren = children.map { $0.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.document(parsedRange: parsedRange, rawChildren))

--- a/Sources/Markdown/Base/Document.swift
+++ b/Sources/Markdown/Base/Document.swift
@@ -66,7 +66,13 @@ public extension Document {
 
     /// Create a document from a sequence of block markup elements.
     init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.document(parsedRange: nil, children.map { $0.raw.markup }))
+        self.init(children, inheritSourceRange: false)
+    }
+
+    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+        let rawChildren = children.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.document(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -196,7 +196,7 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
 
         let parsedRange: SourceRange?
         if preserveRange {
-            parsedRange = header.parsedRange ?? newChild.header.parsedRange
+            parsedRange = header.parsedRange
         } else {
             parsedRange = newChild.header.parsedRange
         }

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -366,3 +366,13 @@ fileprivate extension Sequence where Element == RawMarkup {
         return self.lazy.map { $0.subtreeCount }.reduce(0, +)
     }
 }
+
+extension BidirectionalCollection where Element == RawMarkup {
+    var parsedRange: SourceRange? {
+        if let lowerBound = first?.parsedRange?.lowerBound, let upperBound = last?.parsedRange?.upperBound {
+            return lowerBound..<upperBound
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
@@ -30,7 +30,13 @@ public extension BlockQuote {
     // MARK: BasicBlockContainer
 
     init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.blockQuote(parsedRange: nil, children.map { $0.raw.markup }))
+        self.init(children, inheritSourceRange: false)
+    }
+
+    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+        let rawChildren = children.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.blockQuote(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockQuote.swift
@@ -29,11 +29,11 @@ public struct BlockQuote: BlockMarkup, BasicBlockContainer {
 public extension BlockQuote {
     // MARK: BasicBlockContainer
 
-    init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup {
+    init(_ children: some Sequence<BlockMarkup>) {
         self.init(children, inheritSourceRange: false)
     }
 
-    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+    init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
         let rawChildren = children.map { $0.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.blockQuote(parsedRange: parsedRange, rawChildren))

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
@@ -30,7 +30,13 @@ public struct CustomBlock: BlockMarkup, BasicBlockContainer {
 
 public extension CustomBlock {
     init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup {
-        try! self.init(.customBlock(parsedRange: nil, children.map { $0.raw.markup }))
+        self.init(children, inheritSourceRange: false)
+    }
+
+    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+        let rawChildren = children.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.customBlock(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/CustomBlock.swift
@@ -29,11 +29,11 @@ public struct CustomBlock: BlockMarkup, BasicBlockContainer {
 // MARK: - Public API
 
 public extension CustomBlock {
-    init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup {
+    init(_ children: some Sequence<BlockMarkup>) {
         self.init(children, inheritSourceRange: false)
     }
 
-    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+    init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
         let rawChildren = children.map { $0.raw.markup }
         let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
         try! self.init(.customBlock(parsedRange: parsedRange, rawChildren))

--- a/Sources/Markdown/Block Nodes/Inline Container Blocks/Paragraph.swift
+++ b/Sources/Markdown/Block Nodes/Inline Container Blocks/Paragraph.swift
@@ -29,8 +29,14 @@ public struct Paragraph: BlockMarkup, BasicInlineContainer {
 public extension Paragraph {
     // MARK: InlineContainer
 
-    init<Children: Sequence>(_ newChildren: Children) where Children.Element == InlineMarkup {
-        try! self.init(.paragraph(parsedRange: nil, newChildren.map { $0.raw.markup }))
+    init(_ newChildren: some Sequence<InlineMarkup>) {
+        self.init(newChildren, inheritSourceRange: false)
+    }
+
+    init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
+        let rawChildren = newChildren.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.paragraph(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Block Nodes/Tables/TableCell.swift
+++ b/Sources/Markdown/Block Nodes/Tables/TableCell.swift
@@ -66,12 +66,22 @@ public extension Table.Cell {
 
     // MARK: BasicInlineContainer
 
-    init<Children>(_ children: Children) where Children : Sequence, Children.Element == InlineMarkup {
+    init(_ children: some Sequence<InlineMarkup>) {
         self.init(colspan: 1, rowspan: 1, children)
     }
 
-    init<Children>(colspan: UInt, rowspan: UInt, _ children: Children) where Children : Sequence, Children.Element == InlineMarkup {
-        try! self.init(RawMarkup.tableCell(parsedRange: nil, colspan: colspan, rowspan: rowspan, children.map { $0.raw.markup }))
+    init(_ children: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
+        self.init(colspan: 1, rowspan: 1, children, inheritSourceRange: inheritSourceRange)
+    }
+
+    init(colspan: UInt, rowspan: UInt, _ children: some Sequence<InlineMarkup>) {
+        self.init(colspan: colspan, rowspan: rowspan, children, inheritSourceRange: false)
+    }
+
+    init(colspan: UInt, rowspan: UInt, _ children: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
+        let rawChildren = children.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.tableCell(parsedRange: parsedRange, colspan: colspan, rowspan: rowspan, rawChildren))
     }
 
     // MARK: Visitation

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Emphasis.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Emphasis.swift
@@ -29,8 +29,14 @@ public struct Emphasis: RecurringInlineMarkup, BasicInlineContainer {
 public extension Emphasis {
     // MARK: BasicInlineContainer
 
-    init<Children>(_ newChildren: Children) where Children : Sequence, Children.Element == InlineMarkup {
-        try! self.init(RawMarkup.emphasis(parsedRange: nil, newChildren.map { $0.raw.markup }))
+    init(_ newChildren: some Sequence<InlineMarkup>) {
+        self.init(newChildren, inheritSourceRange: false)
+    }
+
+    init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
+        let rawChildren = newChildren.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.emphasis(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: PlainTextConvertibleMarkup

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strikethrough.swift
@@ -28,8 +28,14 @@ public struct Strikethrough: RecurringInlineMarkup, BasicInlineContainer {
 public extension Strikethrough {
     // MARK: BasicInlineContainer
 
-    init<Children>(_ newChildren: Children) where Children : Sequence, Children.Element == InlineMarkup {
-        try! self.init(.strikethrough(parsedRange: nil, newChildren.map { $0.raw.markup }))
+    init(_ newChildren: some Sequence<InlineMarkup>) {
+        self.init(newChildren, inheritSourceRange: false)
+    }
+
+    init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
+        let rawChildren = newChildren.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.strikethrough(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: PlainTextConvertibleMarkup

--- a/Sources/Markdown/Inline Nodes/Inline Containers/Strong.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Strong.swift
@@ -28,8 +28,14 @@ public struct Strong: RecurringInlineMarkup, BasicInlineContainer {
 public extension Strong {
     // MARK: BasicInlineContainer
 
-    init<Children>(_ newChildren: Children) where Children : Sequence, Children.Element == InlineMarkup {
-        try! self.init(.strong(parsedRange: nil, newChildren.map { $0.raw.markup }))
+    init(_ newChildren: some Sequence<InlineMarkup>) {
+        self.init(newChildren, inheritSourceRange: false)
+    }
+
+    init(_ newChildren: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
+        let rawChildren = newChildren.map { $0.raw.markup }
+        let parsedRange = inheritSourceRange ? rawChildren.parsedRange : nil
+        try! self.init(.strong(parsedRange: parsedRange, rawChildren))
     }
 
     // MARK: PlainTextConvertibleMarkup

--- a/Sources/Markdown/Structural Restrictions/BasicBlockContainer.swift
+++ b/Sources/Markdown/Structural Restrictions/BasicBlockContainer.swift
@@ -12,6 +12,9 @@
 public protocol BasicBlockContainer: BlockContainer {
     /// Create this element from a sequence of block markup elements.
     init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup
+
+    /// Create this element from a sequence of block markup elements, and optionally inherit the source range from those elements.
+    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup
 }
 
 // MARK: - Public API
@@ -19,6 +22,16 @@ public protocol BasicBlockContainer: BlockContainer {
 extension BasicBlockContainer {
     /// Create this element with a sequence of block markup elements.
     public init(_ children: BlockMarkup...) {
+        self.init(children)
+    }
+
+    /// Create this element with a sequence of block markup elements, and optionally inherit the source range from those elements.
+    public init(_ children: BlockMarkup..., inheritSourceRange: Bool) {
+        self.init(children, inheritSourceRange: inheritSourceRange)
+    }
+
+    /// Default implementation of `init(_:inheritSourceRange:)` that discards the `inheritSourceRange` parameter.
+    public init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
         self.init(children)
     }
 }

--- a/Sources/Markdown/Structural Restrictions/BasicBlockContainer.swift
+++ b/Sources/Markdown/Structural Restrictions/BasicBlockContainer.swift
@@ -11,10 +11,10 @@
 /// A block element that can contain only other block elements and doesn't require any other information.
 public protocol BasicBlockContainer: BlockContainer {
     /// Create this element from a sequence of block markup elements.
-    init<Children: Sequence>(_ children: Children) where Children.Element == BlockMarkup
+    init(_ children: some Sequence<BlockMarkup>)
 
     /// Create this element from a sequence of block markup elements, and optionally inherit the source range from those elements.
-    init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup
+    init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool)
 }
 
 // MARK: - Public API
@@ -31,7 +31,7 @@ extension BasicBlockContainer {
     }
 
     /// Default implementation of `init(_:inheritSourceRange:)` that discards the `inheritSourceRange` parameter.
-    public init<Children: Sequence>(_ children: Children, inheritSourceRange: Bool) where Children.Element == BlockMarkup {
+    public init(_ children: some Sequence<BlockMarkup>, inheritSourceRange: Bool) {
         self.init(children)
     }
 }

--- a/Sources/Markdown/Structural Restrictions/BasicInlineContainer.swift
+++ b/Sources/Markdown/Structural Restrictions/BasicInlineContainer.swift
@@ -11,12 +11,24 @@
 /// A block or inline markup element that can contain only `InlineMarkup` elements and doesn't require any other information.
 public protocol BasicInlineContainer: InlineContainer {
     /// Create this element with a sequence of inline markup elements.
-    init<Children: Sequence>(_ children: Children) where Children.Element == InlineMarkup 
+    init(_ children: some Sequence<InlineMarkup>)
+
+    /// Create this element with a sequence of inline markup elements, and optionally inherit the source range from those elements.
+    init(_ children: some Sequence<InlineMarkup>, inheritSourceRange: Bool)
 }
 
 extension BasicInlineContainer {
     /// Create this element with a sequence of inline markup elements.
     public init(_ children: InlineMarkup...) {
+        self.init(children)
+    }
+
+    public init(_ children: InlineMarkup..., inheritSourceRange: Bool) {
+        self.init(children, inheritSourceRange: inheritSourceRange)
+    }
+
+    /// Default implementation for `init(_:inheritSourceRange:)` that discards the `inheritSourceRange` parameter.
+    public init(_ children: some Sequence<InlineMarkup>, inheritSourceRange: Bool) {
         self.init(children)
     }
 }

--- a/Tests/MarkdownTests/Structural Restrictions/BasicBlockContainerTests.swift
+++ b/Tests/MarkdownTests/Structural Restrictions/BasicBlockContainerTests.swift
@@ -110,4 +110,22 @@ final class BasicBlockContainerTests: XCTestCase {
             """
         XCTAssertEqual(expectedDump, newDocument.debugDescription())
     }
+
+    func testInheritSourceRange() throws {
+        let source = "Note: This is just a paragraph."
+        let fakeFileLocation = URL(fileURLWithPath: "/path/to/some-file.md")
+        let document = Document(parsing: source, source: fakeFileLocation)
+        let paragraph = try XCTUnwrap(document.child(at: 0) as? Paragraph)
+
+        // this block quote has no source information, but its children do
+        let blockQuote = BlockQuote(paragraph, inheritSourceRange: true)
+
+        let expectedRootDump = """
+        BlockQuote @/path/to/some-file.md:1:1-/path/to/some-file.md:1:32
+        └─ Paragraph @/path/to/some-file.md:1:1-/path/to/some-file.md:1:32
+           └─ Text @/path/to/some-file.md:1:1-/path/to/some-file.md:1:32 "Note: This is just a paragraph."
+        """
+
+        XCTAssertEqual(expectedRootDump, blockQuote.debugDescription(options: .printSourceLocations))
+    }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://136218537

## Summary

The `subsitutingChild(_:through:)` method on RawMarkup introduced in https://github.com/swiftlang/swift-markdown/pull/196 has the option to preserve the element's original source range. However, this fell back to the new child's range if its parent had no source range. This caused an issue where the assertion in the Aside initializer was being tripped when a BlockQuote had no parsed range, but its inner Paragraph did. This PR removes the fallback and just copies in the parent's source range if the `preserveRange` option is set.

In a separate commit, i also added a new initializer requirement to `BasicBlockContainer` that adds an `inheritSourceRange` option, to allow the new container to inherit the source range of its children even though it's a synthetic wrapper. This method can be used in Swift-DocC when a list item is converted into an aside to propagate that source range up through the new aside.

## Dependencies

None

## Testing

As this is an API change, the functionality is covered by automated testing.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
