### PR TITLE
parameter updates in documentation

### DIFF
--- a/Sources/Markdown/Block Nodes/Tables/Table.swift
+++ b/Sources/Markdown/Block Nodes/Tables/Table.swift
@@ -52,7 +52,7 @@ public extension Table {
     ///
     /// - parameter columnAlignments: An optional list of alignments for each column,
     ///   truncated or expanded with `nil` to fit the table's maximum column count.
-    /// - parameter head: A ``Table/Head-swift.struct`` element serving as the table's head.
+    /// - parameter header: A ``Table/Head-swift.struct`` element serving as the table's head.
     /// - parameter body: A ``Table/Body-swift.struct`` element serving as the table's body.
     init(columnAlignments: [ColumnAlignment?]? = nil,
          header: Head = Head(),

--- a/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
+++ b/Sources/Markdown/Markdown.docc/Markdown/DoxygenCommands.md
@@ -46,7 +46,7 @@ Doxygen commands are not parsed within code blocks or block directive content.
 
 - ``DoxygenDiscussion``
 - ``DoxygenNote``
-- ``DoxygenParam``
+- ``DoxygenParameter``
 - ``DoxygenReturns``
 
 <!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -270,7 +270,7 @@ public protocol MarkupVisitor<Result> {
     /**
     Visit an `InlineAttributes` element and return the result.
 
-    - parameter attribute: An `InlineAttributes` element.
+    - parameter attributes: An `InlineAttributes` element.
     - returns: The result of the visit.
      */
      mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -267,8 +267,9 @@ public struct MarkupFormatter: MarkupWalker {
             - emphasisMarker: The character to use for emphasis and strong emphasis markers.
             - condenseAutolinks: Print links whose link text and destination match as autolinks, e.g. `<https://swift.org>`.
             - preferredHeadingStyle: The preferred heading style.
-            - lineLimit: The preferred maximum line length and method for splitting ``Text`` elements in an attempt to maintain that line length.
+            - preferredLineLimit: The preferred maximum line length and method for splitting ``Text`` elements in an attempt to maintain that line length.
             - customLinePrefix: An addition prefix to print at the start of each line, useful for adding documentation comment markers.
+            - doxygenCommandPrefix: The command command prefix, which defaults to ``DoxygenCommandPrefix/backslash``.
          */
         public init(unorderedListMarker: UnorderedListMarker = .dash,
                     orderedListNumerals: OrderedListNumerals = .allSame(1),
@@ -345,7 +346,7 @@ public struct MarkupFormatter: MarkupWalker {
         /// The length of the last line.
         var lastLineLength = 0
 
-        /// The line number of the most recently printed content. 
+        /// The line number of the most recently printed content.
         ///
         /// This is updated in `addressPendingNewlines(for:)` when line breaks are printed.
         var lineNumber = 0
@@ -543,7 +544,7 @@ public struct MarkupFormatter: MarkupWalker {
             state.currentLength += prefix.count
             state.lastLineLength += prefix.count
         }
-        
+
         result += rawText
         state.currentLength += rawText.count
         state.lastLineLength += rawText.count
@@ -734,7 +735,7 @@ public struct MarkupFormatter: MarkupWalker {
         }
         descendInto(listItem)
     }
-    
+
     public mutating func visitHeading(_ heading: Heading) {
         if heading.indexInParent > 0 {
             ensurePrecedingNewlineCount(atLeast: 2)
@@ -1153,7 +1154,7 @@ public struct MarkupFormatter: MarkupWalker {
             print(attributes.attributes, for: attributes)
             print(")", for: attributes)
         }
-    
+
         printInlineAttributes()
 
         // Inline attributes *can* have their key-value pairs split across multiple


### PR DESCRIPTION
While using this package as test subject while debugging another issue, I noticed a few warnings about misnamed or missing parameters (thank you latest DocC diagnostics!). This updates those to resolve the doc warnings (and correct the documentation)

- resolved warnings generated by latest DocC compilation that
  highlighted missing, renamed, or misnamed parameters within
  the documentation.


