### PR TITLE
Fixes #209, inline tag content is doesn't include nested tags

### DIFF
--- a/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/HTMLFormatter.swift
@@ -215,16 +215,14 @@ public struct HTMLFormatter: MarkupWalker {
 
     // MARK: Inline elements
 
-    mutating func printInline(tag: String, content: String) {
-        result += "<\(tag)>\(content)</\(tag)>"
-    }
-
-    mutating func printInline(tag: String, _ inline: InlineMarkup) {
-        printInline(tag: tag, content: inline.plainText)
+    mutating func printInline(tag: String, _ content: Markup) {
+        result += "<\(tag)>"
+        descendInto(content)
+        result += "</\(tag)>"
     }
 
     public mutating func visitInlineCode(_ inlineCode: InlineCode) -> () {
-        printInline(tag: "code", content: inlineCode.code)
+        result += "<code>\(inlineCode.code)</code>"
     }
 
     public mutating func visitEmphasis(_ emphasis: Emphasis) -> () {
@@ -283,7 +281,7 @@ public struct HTMLFormatter: MarkupWalker {
 
     public mutating func visitSymbolLink(_ symbolLink: SymbolLink) -> () {
         if let destination = symbolLink.destination {
-            printInline(tag: "code", content: destination)
+            result += "<code>\(destination)</code>"
         }
     }
 


### PR DESCRIPTION
Bug/issue #, if applicable: #209 

## Summary

em, strong, and del tags should include their content in a rich format, rather than just their text.

## Dependencies

None

## Testing

Run this program:
```
let markdown = "*Here's some **markdown** with a [link](https://khanlou.com)*"

let html = HTMLFormatter.format(markdown)

print(html)
```
And observe that the nested strong and link tags are included.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
