### PR TITLE
build: adjust the build on Windows to avoid some warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,13 @@ let package = Package(
                 "CAtomic",
                 .product(name: "cmark-gfm", package: cmarkPackageName),
                 .product(name: "cmark-gfm-extensions", package: cmarkPackageName),
-            ], 
+            ],
             exclude: [
                 "CMakeLists.txt"
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"],
+                             .when(platforms: [.windows])),
             ]),
         .testTarget(
             name: "MarkdownTests",


### PR DESCRIPTION
We explicitly build cmark-gfm as static. This adjusts the usage to ensure that the module knows that the cmark that it is building against is static. This fixes a number of linker warnings on Windows.