### PR TITLE
Update package dependencies to use the release/6.2 branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "gfm"),
+        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "release/6.2"),
     ]
     
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Update the package dependencies to target the `release/6.2` branch. For this project, there is only one dependency: [swift-cmark](https://github.com/swiftlang/swift-cmark.git).

## Dependencies

This depends on the existence of the `release/6.2` branch in the swift-cmark repo, which does exist.

## Testing

Clean the SPM cache and run the test suite:

```
% rm -rf .build

% ./bin/test
Fetching https://github.com/swiftlang/swift-cmark.git from cache
Fetched https://github.com/swiftlang/swift-cmark.git from cache (0.62s)
Fetching https://github.com/apple/swift-docc-plugin from cache
Fetching https://github.com/apple/swift-docc-symbolkit from cache
Fetched https://github.com/apple/swift-docc-plugin from cache (0.53s)
Computing version for https://github.com/apple/swift-docc-plugin
Fetched https://github.com/apple/swift-docc-symbolkit from cache (0.65s)
Computed https://github.com/apple/swift-docc-plugin at 1.3.0 (0.94s)
Computing version for https://github.com/apple/swift-docc-symbolkit
Computed https://github.com/apple/swift-docc-symbolkit at 1.0.0 (0.45s)
Creating working copy for https://github.com/apple/swift-docc-plugin
Working copy of https://github.com/apple/swift-docc-plugin resolved at 1.3.0
Creating working copy for https://github.com/swiftlang/swift-cmark.git
Working copy of https://github.com/swiftlang/swift-cmark.git resolved at release/6.2 (b97d094)
Creating working copy for https://github.com/apple/swift-docc-symbolkit
Working copy of https://github.com/apple/swift-docc-symbolkit resolved at 1.0.0
Building for debugging...
[247/247] Linking swift-markdownPackageTests
Build complete! (34.07s)
[288/288] Testing MarkdownTests.TextTests/testWithText
◇ Test run started.
↳ Testing Library Version: 124
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests passed after 0.001 seconds.
=> Checking for unacceptable language… okay.
=> Checking license headers… okay.
=> Validating scripts in bin subdirectory… okay.
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- ~[ ] Added tests~
- [x ] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
