### PR TITLE
Make types Sendable that are useful for AST inspection and library usage

### DIFF
--- a/Sources/Markdown/Base/ChildIndexPath.swift
+++ b/Sources/Markdown/Base/ChildIndexPath.swift
@@ -12,14 +12,14 @@
 public typealias ChildIndexPath = [Int]
 
 /// A description of a traversal through a markup tree by index and optional expected type.
-public struct TypedChildIndexPath: RandomAccessCollection, ExpressibleByArrayLiteral {
+public struct TypedChildIndexPath: RandomAccessCollection, ExpressibleByArrayLiteral, Sendable {
     /// A pair consisting of an expected index and optional expected type for a child element.
     ///
     /// This type is a shorthand convenience when creating a ``TypedChildIndexPath`` from an array literal.
     public typealias ArrayLiteralElement = (Int, Markup.Type?)
 
     /// An element of a complex child index path.
-    public struct Element {
+    public struct Element: Sendable {
         /// The index to use when descending into the children.
         var index: Int
 

--- a/Sources/Markdown/Base/DirectiveArgument.swift
+++ b/Sources/Markdown/Base/DirectiveArgument.swift
@@ -27,10 +27,10 @@
 /// ```
 /// y: 2
 /// ```
-public struct DirectiveArgumentText: Equatable {
+public struct DirectiveArgumentText: Equatable, Sendable {
 
     /// Errors parsing name-value arguments from argument text segments.
-    public enum ParseError: Equatable {
+    public enum ParseError: Equatable, Sendable {
         /// A duplicate argument was given.
         case duplicateArgument(name: String, firstLocation: SourceLocation, duplicateLocation: SourceLocation)
 
@@ -42,7 +42,7 @@ public struct DirectiveArgumentText: Equatable {
     }
 
     /// A segment of a line of argument text.
-    public struct LineSegment: Equatable {
+    public struct LineSegment: Equatable, Sendable {
         /// The original untrimmed text of the line, from which arguments can be parsed.
         public var untrimmedText: String
 
@@ -368,7 +368,7 @@ public struct DirectiveArgumentText: Equatable {
 }
 
 /// A directive argument, parsed from the form `name: value` or `name: "value"`.
-public struct DirectiveArgument: Equatable {
+public struct DirectiveArgument: Equatable, Sendable {
     /// The name of the argument.
     public var name: String
 

--- a/Sources/Markdown/Infrastructure/Replacement.swift
+++ b/Sources/Markdown/Infrastructure/Replacement.swift
@@ -9,7 +9,7 @@
 */
 
 /// A textual replacement.
-public struct Replacement: CustomStringConvertible, CustomDebugStringConvertible {
+public struct Replacement: CustomStringConvertible, CustomDebugStringConvertible, Sendable {
     /// The range of source text to replace.
     public var range: SourceRange
 

--- a/Sources/Markdown/Infrastructure/SourceLocation.swift
+++ b/Sources/Markdown/Infrastructure/SourceLocation.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// A location in a source file.
-public struct SourceLocation: Hashable, CustomStringConvertible, Comparable {
+public struct SourceLocation: Hashable, CustomStringConvertible, Comparable, Sendable {
     public static func < (lhs: SourceLocation, rhs: SourceLocation) -> Bool {
         if lhs.line < rhs.line {
             return true

--- a/Sources/Markdown/Parser/ParseOptions.swift
+++ b/Sources/Markdown/Parser/ParseOptions.swift
@@ -9,7 +9,7 @@
 */
 
 /// Options for parsing Markdown.
-public struct ParseOptions: OptionSet {
+public struct ParseOptions: OptionSet, Sendable {
     public var rawValue: UInt
 
     public init(rawValue: UInt) {


### PR DESCRIPTION
Bug/issue #, if applicable: #170 

## Summary

In Swift 6 language mode, useful descriptions of the AST like `SourceLocation` and `ChildIndexPath`, but also the initial `ParseOptions`, aren't sendable.

While markup cannot be sendable (because of RawMarkup), a lot of types describing parts of the document can. This allows package users to work with e.g. the `SourceRange` of a markup element directly, for example in editors.

## Checklist

- [ ] Added tests -- nothing new to test
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
