### PR TITLE
Sendable markup configurations

### DIFF
--- a/Sources/Markdown/Block Nodes/Block Container Blocks/ListItem.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/ListItem.swift
@@ -9,7 +9,7 @@
 */
 
 /// A checkbox that can represent an on/off state.
-public enum Checkbox {
+public enum Checkbox: Sendable {
     /// The checkbox is checked, representing an "on", "true", or "incomplete" state.
     case checked
     /// The checkbox is unchecked, representing an "off", "false", or "incomplete" state.

--- a/Sources/Markdown/Block Nodes/Tables/Table.swift
+++ b/Sources/Markdown/Block Nodes/Tables/Table.swift
@@ -19,7 +19,7 @@
 /// - Column alignment applies to all cells within in the same column. See ``columnAlignments``.
 public struct Table: BlockMarkup {
     /// The alignment of all cells under a table column.
-    public enum ColumnAlignment {
+    public enum ColumnAlignment: Sendable {
         /// Left alignment.
         case left
 

--- a/Sources/Markdown/Interpretive Nodes/Aside.swift
+++ b/Sources/Markdown/Interpretive Nodes/Aside.swift
@@ -22,7 +22,7 @@ import Foundation
 /// ```
 public struct Aside {
     /// Describes the different kinds of aside.
-    public struct Kind: RawRepresentable, CaseIterable, Equatable {
+    public struct Kind: RawRepresentable, CaseIterable, Equatable, Sendable {
         /// A "note" aside.
         public static let note = Kind(rawValue: "Note")!
         
@@ -161,7 +161,7 @@ public struct Aside {
     }
 
     /// Determines the permissiveness of aside-tag parsing when using ``init(_:tagRequirement:)``.
-    public enum TagRequirement: Equatable {
+    public enum TagRequirement: Equatable, Sendable {
         /// Only allow asides with a single-word aside tag, such as `Warning:` or `Important:`
         case requireSingleWordTag
         /// Require a aside tag, but allow it to be multiple words, such as `See Also:`

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -18,7 +18,7 @@ fileprivate extension String {
 }
 
 /// Options when printing a debug description of a markup tree.
-public struct MarkupDumpOptions: OptionSet {
+public struct MarkupDumpOptions: OptionSet, Sendable {
     public let rawValue: UInt
     public init(rawValue: UInt) {
         self.rawValue = rawValue


### PR DESCRIPTION
Bug/issue #, if applicable: #170 

Extends what I started with in #221 to the content of the AST

## Summary

In Swift 6 language mode, configuring some markup nodes like checkboxes or table alignments will error-out because the types aren't sendable.

While markup cannot be sendable (because of RawMarkup), the structs I picked for this PR can.

## Checklist

- [ ] Added tests -- nothing new to test
- [x] Ran the `./bin/test` script and it succeededk
- [x] Updated documentation if necessary
