### PR TITLE
parse Doxygen commands if a previous block directive is being truncated

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -799,9 +799,7 @@ struct ParseContainerStack {
 
         guard !isInBlockDirective else { return false }
 
-        if case .blockDirective = top {
-            return false
-        } else if case .lineRun(_, isInCodeFence: let codeFence) = top {
+        if case .lineRun(_, isInCodeFence: let codeFence) = top {
             return !codeFence
         } else {
             return true

--- a/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -433,6 +433,34 @@ class DoxygenCommandParserTests: XCTestCase {
         Document
         └─ Paragraph
            └─ Text "\unknown"
+        """#
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testRunOnDirectivesAllowDoxygenParsing() {
+        let source = #"""
+        @method doSomethingWithNumber:
+        @abstract Some brief description of this method
+        @param number Some description of the "number" parameter
+        @return Some description of the return value
+        @discussion Some longer discussion for this method
+        """#
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = #"""
+        Document
+        ├─ BlockDirective name: "method"
+        ├─ BlockDirective name: "abstract"
+        ├─ DoxygenParameter parameter: number
+        │  └─ Paragraph
+        │     └─ Text "Some description of the “number” parameter"
+        ├─ DoxygenReturns
+        │  └─ Paragraph
+        │     └─ Text "Some description of the return value"
+        └─ DoxygenDiscussion
+           └─ Paragraph
+              └─ Text "Some longer discussion for this method"
         """#
         XCTAssertEqual(document.debugDescription(), expectedDump)
     }

--- a/bin/check-source
+++ b/bin/check-source
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
+    sed -e 's/20[12][789012345]-20[12][89012345]/YEARS/' -e 's/20[12][89012345]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "
@@ -151,6 +151,7 @@ EOF
     cd "$here/.."
     find . \
       \( \! -path './.build/*' -a \
+      \! -path './Tools/.build/*' -a \
       \! -name '.' -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://147921223

## Summary

While Swift-Markdown has support for a limited number of Doxygen commands, the parsing logic for them has an error: When a previous block directive is present, even if it's not ready to parse content, the parser blocks Doxygen commands from being parsed. This prevents supported Doxygen commands from being parsed if they are immediately preceded by unsupported Doxygen commands, as the included test demonstrates.

This PR updates the parser logic to allow Doxygen commands to be parsed if the current state of the parser contains a block directive, so long as it is not accepting content.

## Dependencies

None

## Testing

To verify the behavior of the included test outside of the test harness, use the following "markdown" file:

```
@method doSomethingWithNumber:
@abstract Some brief description of this method
@param number Some description of the "number" parameter
@return Some description of the return value
@discussion Some longer discussion for this method
```

Steps:
1. Paste the above text into `test.md`.
2. `swift run --package-path Tools markdown-tool dump-tree --parse-block-directives --experimental-parse-doxygen-commands test.md`
3. Ensure that the `@param`, `@return`, and `@discussion` commands correctly parse into their respective Doxygen command nodes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
