### PR TITLE
[6.2] parse Doxygen commands if a previous directive is being truncated

### DIFF
--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -799,9 +799,7 @@ struct ParseContainerStack {
 
         guard !isInBlockDirective else { return false }
 
-        if case .blockDirective = top {
-            return false
-        } else if case .lineRun(_, isInCodeFence: let codeFence) = top {
+        if case .lineRun(_, isInCodeFence: let codeFence) = top {
             return !codeFence
         } else {
             return true

--- a/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/BlockDirectiveParserTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
+++ b/Tests/MarkdownTests/Parsing/DoxygenCommandParserTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -433,6 +433,34 @@ class DoxygenCommandParserTests: XCTestCase {
         Document
         └─ Paragraph
            └─ Text "\unknown"
+        """#
+        XCTAssertEqual(document.debugDescription(), expectedDump)
+    }
+
+    func testRunOnDirectivesAllowDoxygenParsing() {
+        let source = #"""
+        @method doSomethingWithNumber:
+        @abstract Some brief description of this method
+        @param number Some description of the "number" parameter
+        @return Some description of the return value
+        @discussion Some longer discussion for this method
+        """#
+
+        let document = Document(parsing: source, options: parseOptions)
+
+        let expectedDump = #"""
+        Document
+        ├─ BlockDirective name: "method"
+        ├─ BlockDirective name: "abstract"
+        ├─ DoxygenParameter parameter: number
+        │  └─ Paragraph
+        │     └─ Text "Some description of the “number” parameter"
+        ├─ DoxygenReturns
+        │  └─ Paragraph
+        │     └─ Text "Some description of the return value"
+        └─ DoxygenDiscussion
+           └─ Paragraph
+              └─ Text "Some longer discussion for this method"
         """#
         XCTAssertEqual(document.debugDescription(), expectedDump)
     }

--- a/bin/check-source
+++ b/bin/check-source
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
+    sed -e 's/20[12][789012345]-20[12][89012345]/YEARS/' -e 's/20[12][89012345]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "
@@ -151,6 +151,7 @@ EOF
     cd "$here/.."
     find . \
       \( \! -path './.build/*' -a \
+      \! -path './Tools/.build/*' -a \
       \! -name '.' -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do


### PR DESCRIPTION
  - **Explanation**: Doxygen commands should not be parsed if they would appear in the middle of a block directive, but the current detection is too stringent. Update the detection to only block Doxygen commands if we're in the middle of block directive *contents*.
  - **Scope**: Allows some Doxygen/HeaderDoc-commented input (where commands are stacked next to each other without intervening blank lines) to correctly parse the commands that are supported even if they are preceded by unsupported commands.
  - **Issues**: rdar://147921223
  - **Original PRs**: https://github.com/swiftlang/swift-markdown/pull/223
  - **Risk**: Low. This is a behavior change, but the situations that it occurs in are relatively uncommon and will only improve in functionality.
  - **Testing**: Automated tests have been added.
  - **Reviewers**: @d-ronnqvist 