### PR TITLE
Add footnotes.

### DIFF
--- a/Sources/Markdown/Base/Markup.swift
+++ b/Sources/Markdown/Base/Markup.swift
@@ -71,6 +71,10 @@ func makeMarkup(_ data: _MarkupData) -> Markup {
         return SymbolLink(data)
     case .inlineAttributes:
         return InlineAttributes(data)
+    case .footnoteReference:
+        return FootnoteReference(data)
+    case .footnoteDefinition:
+        return FootnoteDefinition(data)
     case .doxygenDiscussion:
         return DoxygenDiscussion(data)
     case .doxygenNote:

--- a/Sources/Markdown/Base/RawMarkup.swift
+++ b/Sources/Markdown/Base/RawMarkup.swift
@@ -52,6 +52,9 @@ enum RawMarkupData: Equatable {
     case tableRow
     case tableCell(colspan: UInt, rowspan: UInt)
 
+    case footnoteReference(footnoteID: String)
+    case footnoteDefinition(footnoteID: String)
+    
     case doxygenDiscussion
     case doxygenNote
     case doxygenAbstract
@@ -345,6 +348,14 @@ final class RawMarkup: ManagedBuffer<RawMarkupHeader, RawMarkup> {
         return .create(data: .tableCell(colspan: colspan, rowspan: rowspan), parsedRange: parsedRange, children: children)
     }
 
+    static func footnoteDefinition(footnoteID: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .footnoteDefinition(footnoteID: footnoteID), parsedRange: parsedRange, children: children)
+    }
+    
+    static func footnoteReference(footnoteID: String, parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
+        return .create(data: .footnoteReference(footnoteID: footnoteID), parsedRange: parsedRange, children: children)
+    }
+    
     static func doxygenDiscussion(parsedRange: SourceRange?, _ children: [RawMarkup]) -> RawMarkup {
         return .create(data: .doxygenDiscussion, parsedRange: parsedRange, children: children)
     }

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/FootnoteDefinition.swift
@@ -1,0 +1,56 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+public struct FootnoteDefinition: BlockContainer {
+    public var _data: _MarkupData
+    init(_ raw: RawMarkup) throws {
+        guard case .footnoteDefinition = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: FootnoteDefinition.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension FootnoteDefinition {
+    // MARK: BasicBlockContainer
+
+    init<Children: Sequence>(footnoteID: String, _ children: Children) where Children.Element == BlockMarkup {
+        try! self.init(.footnoteDefinition(footnoteID: footnoteID, parsedRange: nil, children.map { $0.raw.markup }))
+    }
+
+    init(footnoteID: String, _ children: BlockMarkup...) {
+        self.init(footnoteID: footnoteID, children)
+    }
+
+    var footnoteID: String {
+        get {
+            guard case let .footnoteDefinition(footnoteID: footnoteID) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return footnoteID
+        }
+        set {
+            _data = _data.replacingSelf(.footnoteDefinition(footnoteID: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
+        }
+    }
+
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitFootnoteDefinition(self)
+    }
+}

--- a/Sources/Markdown/Inline Nodes/Inline Containers/FootnoteReference.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/FootnoteReference.swift
@@ -1,0 +1,57 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A reference to a footnote
+public struct FootnoteReference: InlineMarkup, InlineContainer {
+    public var _data: _MarkupData
+
+    init(_ raw: RawMarkup) throws {
+        guard case .footnoteReference = raw.data else {
+            throw RawMarkup.Error.concreteConversionError(from: raw, to: FootnoteReference.self)
+        }
+        let absoluteRaw = AbsoluteRawMarkup(markup: raw, metadata: MarkupMetadata(id: .newRoot(), indexInParent: 0))
+        self.init(_MarkupData(absoluteRaw))
+    }
+
+    init(_ data: _MarkupData) {
+        self._data = data
+    }
+}
+
+// MARK: - Public API
+
+public extension FootnoteReference {
+    init<Children: Sequence>(footnoteID: String, _ children: Children) where Children.Element == RecurringInlineMarkup {
+        try! self.init(.footnoteReference(footnoteID: footnoteID, parsedRange: nil, children.map { $0.raw.markup }))
+    }
+
+    init(footnoteID: String, _ children: RecurringInlineMarkup...) {
+        self.init(footnoteID: footnoteID, children)
+    }
+
+    /// The identifier of the footnote definition this reference points to.
+    var footnoteID: String {
+        get {
+            guard case let .footnoteReference(footnoteID: footnoteID) = _data.raw.markup.data else {
+                fatalError("\(self) markup wrapped unexpected \(_data.raw)")
+            }
+            return footnoteID
+        }
+        set {
+            _data = _data.replacingSelf(.footnoteReference(footnoteID: newValue, parsedRange: nil, _data.raw.markup.copyChildren()))
+        }
+    }
+
+    // MARK: Visitation
+
+    func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {
+        return visitor.visitFootnoteReference(self)
+    }
+}

--- a/Sources/Markdown/Rewriter/MarkupRewriter.swift
+++ b/Sources/Markdown/Rewriter/MarkupRewriter.swift
@@ -87,4 +87,11 @@ extension MarkupRewriter {
     public mutating func visitText(_ text: Text) -> Result {
         return defaultVisit(text)
     }
+    public mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> Result {
+        return defaultVisit(footnoteReference)
+    }
+
+    public mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> Result {
+        return defaultVisit(footnoteDefinition)
+    }
 }

--- a/Sources/Markdown/Visitor/MarkupVisitor.swift
+++ b/Sources/Markdown/Visitor/MarkupVisitor.swift
@@ -276,6 +276,22 @@ public protocol MarkupVisitor<Result> {
      mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result
 
     /**
+    Visit a `FootnoteReference` element and return the result.
+
+    - parameter footnoteReference: A `FootnoteReference` element.
+    - returns: The result of the visit.
+     */
+    mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> Result
+
+    /**
+    Visit a `FootnoteDefinition` element and return the result.
+
+    - parameter footnoteDefinition: A `FootnoteDefinition` element.
+    - returns: The result of the visit.
+     */
+    mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> Result
+
+    /**
      Visit a `DoxygenDiscussion` element and return the result.
 
      - parameter doxygenDiscussion: A `DoxygenDiscussion` element.
@@ -412,6 +428,12 @@ extension MarkupVisitor {
     }
     public mutating func visitInlineAttributes(_ attributes: InlineAttributes) -> Result {
         return defaultVisit(attributes)
+    }
+    public mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> Result {
+        return defaultVisit(footnoteReference)
+    }
+    public mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> Result {
+        return defaultVisit(footnoteDefinition)
     }
     public mutating func visitDoxygenDiscussion(_ doxygenDiscussion: DoxygenDiscussion) -> Result {
         return defaultVisit(doxygenDiscussion)

--- a/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupTreeDumper.swift
@@ -287,6 +287,14 @@ struct MarkupTreeDumper: MarkupWalker {
         dump(attributes, customDescription: "attributes: `\(attributes.attributes)`")
     }
 
+    mutating func visitFootnoteReference(_ footnoteReference: FootnoteReference) -> () {
+        dump(footnoteReference, customDescription: "footnoteID: `\(footnoteReference.footnoteID)`")
+    }
+
+    mutating func visitFootnoteDefinition(_ footnoteDefinition: FootnoteDefinition) -> () {
+        dump(footnoteDefinition, customDescription: "footnoteID: `\(footnoteDefinition.footnoteID)`")
+    }
+    
     mutating func visitDoxygenParameter(_ doxygenParam: DoxygenParameter) -> () {
         dump(doxygenParam, customDescription: "parameter: \(doxygenParam.name)")
     }

--- a/Tests/MarkdownTests/Block Nodes/FootnoteTests.swift
+++ b/Tests/MarkdownTests/Block Nodes/FootnoteTests.swift
@@ -1,0 +1,70 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import Markdown
+import XCTest
+
+class FootnoteTests: XCTestCase {
+    func testSimpleFootnote() {
+        let source = """
+        text with a footnote [^1].
+        [^1]: footnote definition.
+        """
+
+        let document = Document(parsing: source)
+
+        let expectedDump = """
+        Document @1:1-2:27
+        ├─ Paragraph @1:1-1:27
+        │  ├─ Text @1:1-1:22 "text with a footnote "
+        │  ├─ FootnoteReference @1:22-1:26 footnoteID: `1`
+        │  └─ Text @1:26-1:27 "."
+        └─ FootnoteDefinition @2:7-2:27 footnoteID: `1`
+           └─ Paragraph @2:7-2:27
+              └─ Text @2:7-2:27 "footnote definition."
+        """
+
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+
+    func testBlockFootnote() {
+        let source = """
+        text with a block footnote [^1].
+        [^1]: This is a long footnote, including a quote:
+
+            > This is a multi-line quote, spanning
+            > multiple lines.
+
+            And then some more text.
+        """
+
+        let document = Document(parsing: source)
+
+        let expectedDump = """
+        Document @1:1-7:29
+        ├─ Paragraph @1:1-1:33
+        │  ├─ Text @1:1-1:28 "text with a block footnote "
+        │  ├─ FootnoteReference @1:28-1:32 footnoteID: `1`
+        │  └─ Text @1:32-1:33 "."
+        └─ FootnoteDefinition @2:7-7:29 footnoteID: `1`
+           ├─ Paragraph @2:7-2:50
+           │  └─ Text @2:7-2:50 "This is a long footnote, including a quote:"
+           ├─ BlockQuote @4:5-5:22
+           │  └─ Paragraph @4:7-5:22
+           │     ├─ Text @4:7-4:43 "This is a multi-line quote, spanning"
+           │     ├─ SoftBreak
+           │     └─ Text @5:7-5:22 "multiple lines."
+           └─ Paragraph @7:5-7:29
+              └─ Text @7:5-7:29 "And then some more text."
+        """
+
+        XCTAssertEqual(expectedDump, document.debugDescription(options: .printSourceLocations))
+    }
+  }


### PR DESCRIPTION
This relies on the footnote extension in cmark, which does not expose footnote type names, but does expose enough information via the type enum.

Bug/issue #, if applicable: 

## Summary

Adds new footnote types FootnoteDefinition and FootnoteReference to the markdown tree.

## Dependencies

None. It would be *nice* to use https://github.com/swiftlang/swift-cmark/pull/57, but it's not necessary; there's a small hack that can reliably detect when cmake produces footnotes.

This is heavily based on https://github.com/swiftlang/swift-markdown/pull/129, which also adds footnote support; however, that PR *does* rely on the upstream swift-cmark PR, whereas this one does not.

## Testing

New test introduced to verify the parsing of footnotes, which pass with `./bin/test`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
