### PR TITLE
Index out of range during parsing Crash Fix

### DIFF
--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
@@ -90,11 +90,14 @@ public extension BlockDirective {
     init<Children: Sequence>(name: String,
                              argumentText: String? = nil,
                              children: Children) where Children.Element == BlockMarkup {
-        let argumentSegments = argumentText?.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map { lineText -> DirectiveArgumentText.LineSegment in
-                                                    let untrimmedText = String(lineText)
-                                                    return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedText,
-                                                                                             range: nil)
-                                                   } ?? []
+        let argumentSegments = argumentText?.split(
+            omittingEmptySubsequences: false,
+            whereSeparator: \.isNewline
+        ).map { lineText -> DirectiveArgumentText.LineSegment in
+            let untrimmedText = String(lineText)
+            return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedText,
+                                                     range: nil)
+        } ?? []
         try! self.init(.blockDirective(name: name,
                                        nameLocation: nil,
                                        argumentText: DirectiveArgumentText(segments: argumentSegments),

--- a/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
+++ b/Sources/Markdown/Block Nodes/Block Container Blocks/BlockDirective.swift
@@ -90,9 +90,7 @@ public extension BlockDirective {
     init<Children: Sequence>(name: String,
                              argumentText: String? = nil,
                              children: Children) where Children.Element == BlockMarkup {
-        let argumentSegments = argumentText?.split(separator: "\n",
-                                                   maxSplits: .max,
-                                                   omittingEmptySubsequences: false).map { lineText -> DirectiveArgumentText.LineSegment in
+        let argumentSegments = argumentText?.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map { lineText -> DirectiveArgumentText.LineSegment in
                                                     let untrimmedText = String(lineText)
                                                     return DirectiveArgumentText.LineSegment(untrimmedText: untrimmedText,
                                                                                              range: nil)

--- a/Sources/Markdown/Parser/BlockDirectiveParser.swift
+++ b/Sources/Markdown/Parser/BlockDirectiveParser.swift
@@ -537,7 +537,7 @@ private enum ParseContainer: CustomStringConvertible {
         }
 
         mutating private func print<S: StringProtocol>(_ text: S) {
-            let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
             for i in lines.indices {
                 if i != lines.startIndex {
                     queueNewline()

--- a/Sources/Markdown/Parser/LazySplitLines.swift
+++ b/Sources/Markdown/Parser/LazySplitLines.swift
@@ -28,7 +28,7 @@ struct LazySplitLines: Sequence {
         private var source: URL?
 
         init<S: StringProtocol>(_ input: S, source: URL?) where S.SubSequence == Substring {
-            self.rawLines = input.split(separator: "\n", maxSplits: Int.max, omittingEmptySubsequences: false)
+            self.rawLines = input.components(separatedBy: CharacterSet.newlines).map { Substring($0) }
             self.index = rawLines.startIndex
             self.source = source
         }

--- a/Sources/Markdown/Parser/LazySplitLines.swift
+++ b/Sources/Markdown/Parser/LazySplitLines.swift
@@ -28,7 +28,7 @@ struct LazySplitLines: Sequence {
         private var source: URL?
 
         init<S: StringProtocol>(_ input: S, source: URL?) where S.SubSequence == Substring {
-            self.rawLines = input.components(separatedBy: CharacterSet.newlines).map { Substring($0) }
+            self.rawLines = input.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
             self.index = rawLines.startIndex
             self.source = source
         }

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -38,7 +38,7 @@ fileprivate extension Markup {
 fileprivate extension String {
     /// This string, split by newline characters, dropping leading and trailing lines that are empty.
     var trimmedLineSegments: ArraySlice<Substring> {
-        var splitLines = split(separator: "\n", omittingEmptySubsequences: false)[...].drop { $0.isEmpty }
+        var splitLines = split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)[...].drop { $0.isEmpty }
         while let lastLine = splitLines.last, lastLine.isEmpty {
             splitLines = splitLines.dropLast()
         }

--- a/Tests/MarkdownTests/Block Nodes/DocumentTests.swift
+++ b/Tests/MarkdownTests/Block Nodes/DocumentTests.swift
@@ -40,4 +40,23 @@ final class DocumentTests: XCTestCase {
         XCTAssertThrowsError(try Document(parsing: URL(fileURLWithPath: #file)
             .appendingPathComponent("doesntexist")))
     }
+ 
+    func testDocumentContainsCharactersRepresentatingNewLines() {
+        let inputParagraphString = """
+        # First\n
+        ## Second\r
+        ### Third\r\n
+        """
+        let document = Document(parsing: inputParagraphString, options: [.parseBlockDirectives, .parseSymbolLinks])
+        let expectedDump = """
+                Document
+                ├─ Heading level: 1
+                │  └─ Text "First"
+                ├─ Heading level: 2
+                │  └─ Text "Second"
+                └─ Heading level: 3
+                   └─ Text "Third"
+                """
+        XCTAssertEqual(expectedDump, document.debugDescription())
+    }
 }

--- a/Tests/MarkdownTests/Block Nodes/DocumentTests.swift
+++ b/Tests/MarkdownTests/Block Nodes/DocumentTests.swift
@@ -41,7 +41,7 @@ final class DocumentTests: XCTestCase {
             .appendingPathComponent("doesntexist")))
     }
  
-    func testDocumentContainsCharactersRepresentatingNewLines() {
+    func testParseNewlineCharacters() {
         let inputParagraphString = """
         # First\n
         ## Second\r


### PR DESCRIPTION
Fix for crash

https://github.com/swiftlang/swift-markdown/issues/225

## Summary

Lets say we have multiLine string having different characters all represent newlines.
```
let inputString = """
        # First\n
        ## Second\r
        ### Third\r\n
        """
```

While parsing in `Document` which accepts string as input, It crash for `\r\n`
Reason: 
explicitly using `\n` in `split(...` as newLine can have different characters mentioned in [ref apple documentation](https://developer.apple.com/documentation/swift/character/isnewline)

        


## Dependencies

No dependencies as such of now.

## Testing

_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
applicable._

Steps:
Text used:
```
let inputString = """
        # First\n
        ## Second\r
        ### Third\r\n
        """
 _ = Document(parsing: inputText, options: [.parseBlockDirectives, .parseSymbolLinks]) 
 ```

And it worked fine

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
