### PR TITLE
Guard unsafeFlags with Windows-only conditional to restore SwiftPM compatibility (#239)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,14 @@ import class Foundation.ProcessInfo
 
 let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "cmark"
 
+// On non-Windows, do not include unsafe flags so SwiftPM allows tagged dependency usage.
+var markdownSwiftSettings: [SwiftSetting] = []
+#if os(Windows)
+markdownSwiftSettings.append(
+    .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"], .when(platforms: [.windows]))
+)
+#endif
+
 let package = Package(
     name: "swift-markdown",
     products: [
@@ -32,10 +40,8 @@ let package = Package(
             exclude: [
                 "CMakeLists.txt"
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"],
-                             .when(platforms: [.windows])),
-            ]),
+            swiftSettings: markdownSwiftSettings
+        ),
         .testTarget(
             name: "MarkdownTests",
             dependencies: ["Markdown"],


### PR DESCRIPTION
Bug/issue #239 

## Summary

This PR addresses the SwiftPM resolution failure introduced in version 0.7.0 where the `Markdown` target included `unsafeFlags` in its `swiftSettings`.

On non-Windows platforms (iOS, macOS, Linux), SwiftPM forbids depending on packages that contain unsafe build flags as tagged dependencies, leading to errors like: `the target ‘Markdown’ in product ‘Markdown’ contains unsafe build flags`

**Implementation overview**
- Refactored `swiftSettings` so that `unsafeFlags` are only included when building on Windows.
- On non-Windows, the manifest no longer includes `unsafeFlags`, restoring SwiftPM compatibility.

## Dependencies

None.  
(Future work may involve updating `swift-cmark` to move the `CMARK_GFM_STATIC_DEFINE` into its `cSettings`.)


## Testing

Steps:
1. Add this branch as a dependency in a SwiftPM project (iOS/macOS).
   ```swift
   .package(url: "https://github.com/dlskawns96/swift-markdown.git",
            .branch("fix/guard-unsafeflags-nonwindows"))
2.	Run xcodebuild -resolvePackageDependencies or open in Xcode.
3.	Confirm the package resolves successfully (previously failed with unsafe flags error).
4.	On Windows, verify that the build still succeeds with the required CMARK_GFM_STATIC_DEFINE.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests (not applicable, this is a manifest-only change)
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
