### PR TITLE
[Swift-Markdown 0.7.x] Guard unsafeFlags with Windows-only conditional to restore SwiftPM compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,14 @@ import class Foundation.ProcessInfo
 
 let cmarkPackageName = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil ? "swift-cmark" : "cmark"
 
+// On non-Windows, do not include unsafe flags so SwiftPM allows tagged dependency usage.
+var markdownSwiftSettings: [SwiftSetting] = []
+#if os(Windows)
+markdownSwiftSettings.append(
+    .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"], .when(platforms: [.windows]))
+)
+#endif
+
 let package = Package(
     name: "swift-markdown",
     products: [
@@ -32,10 +40,8 @@ let package = Package(
             exclude: [
                 "CMakeLists.txt"
             ],
-            swiftSettings: [
-                .unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"],
-                             .when(platforms: [.windows])),
-            ]),
+            swiftSettings: markdownSwiftSettings
+        ),
         .testTarget(
             name: "MarkdownTests",
             dependencies: ["Markdown"],


### PR DESCRIPTION
- **Explanation**: Gate the inclusion of `unsafeFlags` in Package.swift to only Windows, so that tagged semver releases can still be made.
- **Scope**: Resolves an issue where the `0.7.0` release tag was unusable on non-Windows platforms due to the use of `unsafeFlags`.
- **Issues**: https://github.com/swiftlang/swift-markdown/issues/239
- **Original PRs**: https://github.com/swiftlang/swift-markdown/pull/240
- **Risk**: Very low. The flag was already being guarded to only be included on Windows anyway, so the extra compile-time guard introduces no behavioral change.
- **Reviewers**: Me