### PR TITLE
split the unsafeFlags-using manifest to a Swift 6.2 minimum version

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:5.7
 /*
  This source file is part of the Swift.org open source project
 
@@ -31,16 +31,14 @@ let package = Package(
             ],
             exclude: [
                 "CMakeLists.txt"
-            ],
-            swiftSettings: [.unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"], .when(platforms: [.windows]))]
+            ]
         ),
         .testTarget(
             name: "MarkdownTests",
             dependencies: ["Markdown"],
             resources: [.process("Visitors/Everything.md")]),
         .target(name: "CAtomic"),
-    ],
-    swiftLanguageModes: [.v5]
+    ]
 )
 
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

The patch to Package.swift introduced in https://github.com/swiftlang/swift-markdown/pull/240 is an incomplete fix. It turns out that _all_ platforms blocked `unsafeFlags` in dependencies, specifically prior to the release of Swift 6.2. However, this is predicated on the package's `swift-tools-version`, not just the version of SwiftPM is being used to build the package.

This PR splits the package manifest into two versions:
1. The default `Package.swift` now requires a tools-version of 6.2, and reinstates the use of `unsafeFlags` as of https://github.com/swiftlang/swift-markdown/pull/213, so that Windows builds (even builds being cross-compiled from other platforms) can correctly build Swift-Markdown and swift-cmark. This version forces the language mode to Swift 5, to prevent the strict concurrency checking from failing the build.
2. An additional `Package@swift-5.7.swift` manifest reinstates the older variant of the manifest, without any `unsafeFlags`, for use from older toolchains and older tools versions.

I intend to cherry-pick this change onto `release/6.2` and `swift-markdown-0.7`, so that a proper fix can be present in both toolchain builds and package uses.

## Dependencies

None

## Testing

To verify the desired behavior, i have pushed a tag to my personal fork, [`9999.0.0-alpha.2`](https://github.com/QuietMisdreavus/swift-markdown/releases/tag/9999.0.0-alpha.2), that can be used to verify the desired behavior. This can be used with the following dependency declaration:

```swift
    dependencies: [
        .package(url: "https://github.com/QuietMisdreavus/swift-markdown.git", from: "9999.0.0-alpha.2")
    ],
```

I have tested building such a package dependency with both Swift 6.2 (via Xcode 26) and Swift 6.0 (via Xcode 16), without issue.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
