### PR TITLE
[6.2] split the unsafeFlags-using manifest to a Swift 6.2 minimum version

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:5.7
 /*
  This source file is part of the Swift.org open source project
 
@@ -31,16 +31,14 @@ let package = Package(
             ],
             exclude: [
                 "CMakeLists.txt"
-            ],
-            swiftSettings: [.unsafeFlags(["-Xcc", "-DCMARK_GFM_STATIC_DEFINE"], .when(platforms: [.windows]))]
+            ]
         ),
         .testTarget(
             name: "MarkdownTests",
             dependencies: ["Markdown"],
             resources: [.process("Visitors/Everything.md")]),
         .target(name: "CAtomic"),
-    ],
-    swiftLanguageModes: [.v5]
+    ]
 )
 
 // If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set,
@@ -49,7 +47,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // Building standalone, so fetch all dependencies remotely.
     package.dependencies += [
-        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "release/6.2"),
+        .package(url: "https://github.com/swiftlang/swift-cmark.git", branch: "gfm"),
     ]
     
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.


### PR DESCRIPTION
- **Explanation**: Reinstate the use of `unsafeFlags` in Package.swift, by increasing the default swift-tools-version to 6.2 and creating a separate manifest for Swift 5.7.
- **Scope**: Resolves an issue where the fix introduced by #241 prevented the ability to cross-compile to Windows (or to use the package at all from Windows as a semver-tagged dependency).
- **Issues**: https://github.com/swiftlang/swift-markdown/issues/244
- **Original PRs**: https://github.com/swiftlang/swift-markdown/pull/245
- **Risk**: Low. Older toolchains are still able to build Swift-Markdown via the additional manifest, and newer toolchains are able to use `unsafeFlags` in a package dependency.
- **Testing**: See testing notes on #245 
- **Reviewers**: @compnerd @d-ronnqvist 