### PR TITLE
MarkupFormatter: stop condensing relative links into broken autolinks

### DIFF
--- a/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
+++ b/Sources/Markdown/Inline Nodes/Inline Containers/Link.swift
@@ -96,6 +96,49 @@ public extension Link {
         return true
     }
 
+    /// Whether this link can be written as `<destination>` without changing meaning.
+    ///
+    /// Narrower than ``isAutolink``, which asks only whether the link text and the
+    /// destination match. CommonMark reads `<...>` as an autolink only when it holds
+    /// an absolute URI, so `[LICENSE.txt](LICENSE.txt)` fails here: written as
+    /// `<LICENSE.txt>` it would parse back as literal text, and the link would be gone.
+    internal var canBeWrittenAsAutolink: Bool {
+        guard isAutolink, let destination = destination else {
+            return false
+        }
+        return Link.isAbsoluteURI(destination)
+    }
+
+    /// Whether a destination is an absolute URI, and so may be written as an autolink.
+    ///
+    /// CommonMark asks for a scheme of 2 to 32 characters, beginning with an ASCII
+    /// letter and continuing with ASCII letters, digits, `+`, `.` or `-`, followed by
+    /// a colon and then anything but spaces, control characters, or angle brackets.
+    private static func isAbsoluteURI(_ destination: String) -> Bool {
+        guard let colon = destination.firstIndex(of: ":") else {
+            return false
+        }
+        let scheme = destination[destination.startIndex..<colon]
+        guard (2...32).contains(scheme.count),
+              let first = scheme.first,
+              first.isASCII,
+              first.isLetter else {
+            return false
+        }
+        let schemeIsValid = scheme.dropFirst().allSatisfy { character in
+            guard character.isASCII else { return false }
+            return character.isLetter || character.isNumber
+                || character == "+" || character == "." || character == "-"
+        }
+        guard schemeIsValid else {
+            return false
+        }
+        return destination[destination.index(after: colon)...].allSatisfy { character in
+            !character.isWhitespace && character != "<" && character != ">"
+                && !(character.asciiValue.map { $0 < 0x20 } ?? false)
+        }
+    }
+
     // MARK: Visitation
 
     func accept<V: MarkupVisitor>(_ visitor: inout V) -> V.Result {

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -860,7 +860,7 @@ public struct MarkupFormatter: MarkupWalker {
     public mutating func visitLink(_ link: Link) {
         let savedState = state
         if formattingOptions.condenseAutolinks,
-           link.isAutolink,
+           link.canBeWrittenAsAutolink,
            let destination = link.destination {
             print("<\(destination)>", for: link)
         } else {

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -1736,3 +1736,37 @@ class MarkupFormatterMixedContentTests: XCTestCase {
         XCTAssertEqual(expected, printed)
     }
 }
+
+/// Autolink condensing must not turn a link into text.
+class MarkupFormatterAutolinkCondensingTests: XCTestCase {
+    /// `<destination>` only reads back as a link when the destination is an absolute
+    /// URI, so a relative one has to keep its brackets.
+    func testRelativeLinkIsNotCondensed() {
+        let source = "See [LICENSE.txt](LICENSE.txt)."
+        let document = Document(parsing: source)
+        XCTAssertEqual(source, document.format())
+        XCTAssertEqual(document.debugDescription(),
+                       Document(parsing: document.format()).debugDescription())
+    }
+
+    func testAbsoluteURLIsStillCondensed() {
+        let document = Document(parsing: "See [https://example.com](https://example.com).")
+        XCTAssertEqual("See <https://example.com>.", document.format())
+    }
+
+    func testSchemelessDestinationsAreNotCondensed() {
+        for destination in ["example.com", "docs/guide.md", "#anchor", "a:b"] {
+            let document = Document(parsing: "[\(destination)](\(destination))")
+            XCTAssertEqual("[\(destination)](\(destination))", document.format(),
+                           "\(destination) must not be condensed")
+        }
+    }
+
+    func testSchemesThatAreValid() {
+        for destination in ["mailto:a@example.com", "ftp://example.com", "x-custom.scheme+v2:payload"] {
+            let document = Document(parsing: "[\(destination)](\(destination))")
+            XCTAssertEqual("<\(destination)>", document.format(),
+                           "\(destination) should be condensed")
+        }
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

`MarkupFormatter` can silently turn a link into plain text.

```swift
let source = "See [LICENSE.txt](LICENSE.txt)."
Document(parsing: source).format()
// "See <LICENSE.txt>."
```

`<LICENSE.txt>` is not an autolink — CommonMark reads `<...>` as one only when it
contains an absolute URI — so re-parsing that output gives a paragraph of text with
no `Link` in it at all. Formatting a document changed what it means.

The condensing is guarded by `Link.isAutolink`, which checks that the link has a
single `Text` child equal to its destination. That is the right answer to the
question `isAutolink` is documented to answer, but it is not quite the question the
formatter is asking, which is "can this link be written as `<destination>` without
changing meaning". Matching text and destination is necessary for that, and not
sufficient.

This adds an internal `Link.canBeWrittenAsAutolink`, which additionally requires the
destination to be a CommonMark absolute URI: a scheme of 2–32 characters beginning
with an ASCII letter and continuing with ASCII letters, digits, `+`, `.` or `-`,
followed by a colon and then no spaces, control characters or angle brackets.
`MarkupFormatter.visitLink` asks that instead.

`isAutolink` itself is deliberately untouched, along with the test in `LinkTests`
that pins its current behaviour for `example.com`. Narrowing it would change a
documented public API to fix something that belongs to the formatter.

I noticed this because adding a relative link to a README makes this repository's
own `testRoundTripReadMe` fail.

## Dependencies

None.

## Testing

`MarkupFormatterAutolinkCondensingTests` covers it, but it can also be seen directly:

1. Add a relative link such as `See [LICENSE.txt](LICENSE.txt).` anywhere in
   `README.md`.
2. Run `testRoundTripReadMe`. Before this change it fails, because the reparsed tree
   has lost the link; after it, it passes.

The new tests check that absolute URLs are still condensed (`https://example.com`,
`mailto:`, `ftp://`, and an unusual-but-valid `x-custom.scheme+v2:`), that
schemeless destinations are not (`example.com`, `docs/guide.md`, `#anchor`, and
`a:b`, whose scheme is one character short), and that a relative link round-trips
to an identical tree.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary — no user-facing API changed; the new property is internal and documented in source.
